### PR TITLE
use fix full year multi-parameter date constructor and fix full year padding

### DIFF
--- a/datetime-mixin.html
+++ b/datetime-mixin.html
@@ -295,7 +295,9 @@
           this._setDate(d);
         }
         else {
-          this._setDate(new Date(year, month - 1, day, hours, minutes, seconds, milliseconds));
+          var d = new Date(year, month - 1, day, hours, minutes, seconds, milliseconds);
+          d.setFullYear(year);
+          this._setDate(d);
         }
       }
 
@@ -648,6 +650,7 @@
 
       _computeMaxDayOfMonth(year, month) {
         const d = new Date(year, month, 0);
+        d.setFullYear(year);
         if (!isNaN(+d)) {
           return d.getDate() + 1;
         }

--- a/datetime-mixin.html
+++ b/datetime-mixin.html
@@ -510,7 +510,7 @@
         if (isNaN(+d) || !d.getTime)
           return '';
 
-        return d.getFullYear() + '-' + this._pad(d.getMonth() + 1, 2) + '-' + this._pad(d.getDate(), 2);
+        return this._pad(d.getFullYear(), 4) + '-' + this._pad(d.getMonth() + 1, 2) + '-' + this._pad(d.getDate(), 2);
       }
 
       _toTime(d) {


### PR DESCRIPTION
`overlay-date-picker` and other elements depending on `datetime-picker-mixin` and `datetime-mixin` won't play well with dates when the year is set below 1000, forcing `confirmedDate` to be set with the current date. This is a problem, not necessarily because picking a date with one, two or even three digits is a common thing to do, but because it happens when typing in dates using the keyboard.

This happens because:
- the multi-parameter Date constructor, which is being used by the mixins, considers a one- or two-digit value passed as the first parameter to be a year since 1900
- 4-digit padding missing on the `_toDate` method on `datetime-mixin`, which won't follow the `yyyy-mm-dd` format if the year is not a four-digit number
